### PR TITLE
Add image reference integrity test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/tests/test_image_references.py
+++ b/tests/test_image_references.py
@@ -1,0 +1,27 @@
+import unittest
+from pathlib import Path
+import xml.etree.ElementTree as ET
+
+class TestImageReferences(unittest.TestCase):
+    def test_xhtml_image_paths_exist(self):
+        repo_root = Path(__file__).resolve().parents[1]
+        text_dir = repo_root / 'src' / 'epub' / 'text'
+        images_dir = repo_root / 'src' / 'epub' / 'images'
+        ns = {'xhtml': 'http://www.w3.org/1999/xhtml'}
+
+        missing = []
+        for xhtml_file in sorted(text_dir.glob('*.xhtml')):
+            tree = ET.parse(xhtml_file)
+            for img in tree.findall('.//xhtml:img', namespaces=ns):
+                src = img.get('src')
+                if src and src.startswith('../images/'):
+                    rel_path = src[len('../images/'):]
+                    if not (images_dir / rel_path).exists():
+                        missing.append(f"{xhtml_file}: {src}")
+
+        if missing:
+            self.fail('Missing image files:\n' + '\n'.join(missing))
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- add Python test suite to verify that images referenced from XHTML exist
- ignore Python cache files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684914f8668483308bfc0023f9dd5e19