### PR TITLE
Add workflow to build ebook with standard tools

### DIFF
--- a/.github/workflows/build-ebook.yml
+++ b/.github/workflows/build-ebook.yml
@@ -12,10 +12,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install Standard Ebooks tools
         run: |
-          git clone https://github.com/standardebooks/tools ~/se-tools
-          cd ~/se-tools
-          ./se install
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          sudo apt update
+          sudo apt install -y calibre default-jre git python3-dev python3-pip python3-venv pipx
+          pipx install standardebooks
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Clean and build
         run: |
           se clean .

--- a/.github/workflows/build-ebook.yml
+++ b/.github/workflows/build-ebook.yml
@@ -1,0 +1,23 @@
+name: Build Ebook
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Standard Ebooks tools
+        run: |
+          git clone https://github.com/standardebooks/tools ~/se-tools
+          cd ~/se-tools
+          ./se install
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - name: Clean and build
+        run: |
+          se clean .
+          se lint . || true
+          se build .


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that clones the Standard Ebooks tools
- run `se clean`, `se lint` (ignored on failure), and `se build`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849154156e88330935b51ce718cb506